### PR TITLE
docs: link Histology Databank Explorer from data management plan, fix stale README numbers

### DIFF
--- a/docs/Data-Management.md
+++ b/docs/Data-Management.md
@@ -319,6 +319,8 @@ _Taxa Representation in Nightingales_
 
 All images should be stored in the proper species directory at http://owl.fish.washington.edu/hesperornis/
 
+To browse what has already been catalogued, use the [Histology Databank Explorer](histology-explorer/index.html) — it joins the databank sheet to the images on owl so you can search samples by species, project, year, tissue, and researcher, and view the slides. Its "Unmatched images" view lists specimens imaged on owl that have no databank row yet. The Explorer is a snapshot rebuilt from a CSV export of the sheet, so new entries appear only after the next [rebuild](https://github.com/RobertsLab/resources/blob/master/docs/histology-explorer/README.md).
+
 
 
 ---

--- a/docs/histology-explorer/README.md
+++ b/docs/histology-explorer/README.md
@@ -43,8 +43,10 @@ histology-explorer/
 
 Many images (all of `O_angasi`, the 2026 geoduck gonad set) are archival **`.tif`** files,
 which browsers cannot display. The explorer shows browser-viewable `.jpg`/`.png` inline and
-offers `.tif` as a download link. A sample with only `.tif` images shows a "TIF only" card.
-To give those real thumbnails, generate `.jpg` derivatives (see next section).
+offers the `.tif` as a download link. For `.tif` files with a generated `.jpg` derivative, the
+derivative is displayed and the original stays downloadable — 44 of the 100 imaged samples
+currently display this way. A `.tif` with no derivative shows a "TIF only" card; to give those
+real thumbnails, generate derivatives (see next section).
 
 ## Generating JPEG derivatives for `.tif` images
 
@@ -76,9 +78,10 @@ updates `build/derivatives_manifest.csv`. Then:
 ## Current coverage (from the last build)
 
 - 1,308 sheet rows → **940 unique samples**
-- **100 samples** have at least one image; **56** have a browser-viewable image
-- **918 image files** indexed; ~651 are "orphans" — imaged on owl but **not yet entered in the sheet**
-  (e.g. `O_angasi` 45–146, `O_lurida` 241–386, the Larken clam set). See `data/qc_report.md`.
+- **100 samples** have at least one image, all of them browser-viewable
+- **918 image files** indexed; **267** matched to a sample and **651** are "orphans" — imaged on owl
+  but **not yet entered in the sheet** (e.g. `O_angasi` 45–146, `O_lurida` 241–386, the Larken clam
+  set). See `data/qc_report.md`.
 
 ## Viewing locally
 


### PR DESCRIPTION
## What changed

**1. Link the Explorer from the Histology Data Management Plan** (`docs/Data-Management.md`)

The Explorer was already integrated in three places (mkdocs nav under Databases and Catalogs, `docs/index.md`, and `docs/Lab-Inventory.md`). The one place that discussed the databank *without* pointing at the portal was the Histology Data Management Plan — which is where someone actually working with histology lands. Added a pointer right after the owl storage convention, so the page flows from "where images go" to "where you look them up." It calls out the "Unmatched images" backfill view and notes the Explorer is a rebuilt snapshot, not a live read of the sheet.

**2. Fix stale numbers in the Explorer README** (`docs/histology-explorer/README.md`)

The README claimed **56** of the 100 imaged samples had a browser-viewable image; `data/qc_report.json` from the last build says **100**.

The `.tif` note was stale from the same cause and mattered more than the number — it said a `.tif`-only sample shows a "TIF only" card, implying archival sets like `O_angasi` are still placeholders. Reworded to describe the no-derivative case it now actually is.

## Verification

Checked against the shipped data, not just the QC report:

- `build/derivatives_manifest.csv` — 352 rows
- parsing `data/samples.json` — all 100 imaged samples resolve to a viewable image, **44 via generated derivatives**, zero in the TIF-only state

That 56 → 100 jump *is* the derivative run, which is why both stale spots trace to one event.

## Notes for reviewers

- The new link uses the `histology-explorer/index.html` form (matching `Lab-Inventory.md`) rather than the `../` form the Bivalve Histology Tutorial link on the same page uses. Both render correctly on the live site — I checked the deployed HTML — but mkdocs rewrites the former to `../histology-explorer/` itself, without the outside-docs-dir warning the `../` form triggers.
- No new Handbook page was added. The Explorer is a portal onto a databank the Handbook already documents, so it's linked from the existing pages rather than given one of its own.
- `docs/histology-explorer/README.md` is not in the mkdocs nav; it's the maintainer doc the rebuild workflow points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)