### PR TITLE
docs: render Hyak shared-resource callout as an admonition

### DIFF
--- a/docs/Computing-Hardware.md
+++ b/docs/Computing-Hardware.md
@@ -48,29 +48,29 @@ NOTE: All users have access to the checkpoint partition (`ckpt`), but run times 
 | srlab | cpu-g2-mem2x | 32 | 503G | 0 | TOTAL |
 
 
-> [!IMPORTANT]
-> The `coenv` `cpu-g2` is a set of shared resources. We have dedicated access to 32CPUs and 500GB of RAM.
-> If interested in using more than our allocation, you will need to reach out to other PIs to see if you can use some of their allocations.
->
-> #### cpu-g2 (mem2x) Shared Resource Contributions
->
-> | Account                         | CPUs | Memory |
-> |-----------------------------|------|--------|
-> | uwit-cpu-g2-mem2x           | 32   | 490G   |
-> | nrdg-cpu-g2-mem2x           | 32   | 490G   |
-> | psych-cpu-g2-mem2x          | 32   | 490G   |
-> | rheum-cpu-g2-mem2x          | 32   | 490G   |
-> | stf-cpu-g2-mem2x            | 192  | 3010G  |
-> | vsm-cpu-g2-mem2x            | 192  | 3010G  |
-> | comdata-cpu-g2-mem2x        | 32   | 490G   |
-> | stergachislab-cpu-g2-mem2x  | 192  | 3010G  |
-> | radlab-cpu-g2-mem2x         | 32   | 490G   |
-> | carrolllab-cpu-g2-mem2x     | 32   | 490G   |
-> | uwb-cpu-g2-mem2x            | 64   | 994G   |
-> | srlab-cpu-g2-mem2x          | 32   | 490G   |
-> | kawaldorflab-cpu-g2-mem2x   | 32   | 490G   |
-> | astro-cpu-g2-mem2x          | 64   | 994G   |
-> | escience-cpu-g2-mem2x       | 32   | 490G   |
+!!! important
+    The `coenv` `cpu-g2` is a set of shared resources. We have dedicated access to 32CPUs and 500GB of RAM.
+    If interested in using more than our allocation, you will need to reach out to other PIs to see if you can use some of their allocations.
+
+    #### cpu-g2 (mem2x) Shared Resource Contributions
+
+    | Account                         | CPUs | Memory |
+    |-----------------------------|------|--------|
+    | uwit-cpu-g2-mem2x           | 32   | 490G   |
+    | nrdg-cpu-g2-mem2x           | 32   | 490G   |
+    | psych-cpu-g2-mem2x          | 32   | 490G   |
+    | rheum-cpu-g2-mem2x          | 32   | 490G   |
+    | stf-cpu-g2-mem2x            | 192  | 3010G  |
+    | vsm-cpu-g2-mem2x            | 192  | 3010G  |
+    | comdata-cpu-g2-mem2x        | 32   | 490G   |
+    | stergachislab-cpu-g2-mem2x  | 192  | 3010G  |
+    | radlab-cpu-g2-mem2x         | 32   | 490G   |
+    | carrolllab-cpu-g2-mem2x     | 32   | 490G   |
+    | uwb-cpu-g2-mem2x            | 64   | 994G   |
+    | srlab-cpu-g2-mem2x          | 32   | 490G   |
+    | kawaldorflab-cpu-g2-mem2x   | 32   | 490G   |
+    | astro-cpu-g2-mem2x          | 64   | 994G   |
+    | escience-cpu-g2-mem2x       | 32   | 490G   |
 
 **Checkpoint Resources — Idle**
 


### PR DESCRIPTION
## What changed

Converted the `> [!IMPORTANT]` block in `docs/Computing-Hardware.md` (the Hyak/Klone `cpu-g2` shared-resource note) from GitHub-flavored alert syntax to the `!!! important` admonition syntax.

## Why

`mkdocs.yml` doesn't enable an extension that understands GFM alerts, so the marker was passed through as plain text. On the published site the block rendered as a blockquote whose first line was the literal string `[!IMPORTANT]` — see [Computing-Hardware](https://robertslab.github.io/resources/Computing-Hardware/).

The `admonition` extension is already enabled, so `!!!` blocks render correctly today.

## Why this approach over adding `github-callouts`

A grep of `docs/` turned up exactly **one** GFM alert, this one. The other `[!` matches (in `docs/Lab-Notebooks.md`) are false positives — they're `[![shields.io badge]](url)` image links, not alerts. `protocols/` and `README.md` are clean too.

With a single occurrence, adding the `github-callouts` extension would have meant a new third-party dependency in both `mkdocs.yml` and the `pip install` line of `.github/workflows/mkdocs-material-theme.yml` — i.e. on the deploy path — to fix one blockquote. Converting in place uses what's already configured and touches one file.

## Verification

Built locally with the same stack the workflow installs (`mkdocs-material mkdocs-video mkdocs-git-latest-changes-plugin`):

- Build succeeds. The warnings emitted are all pre-existing broken cross-links in `bio_Basics.md`, `klone_Conda.md`, and `klone_RStudio-Server.md`, unrelated to this change and present beforehand.
- `grep -rn '\[!' site/ --include='*.html'` returns zero matches.
- The block renders as `<div class="admonition important">` with an "Important" title; the nested `####` heading and the shared-resource contributions table both render properly inside the admonition rather than as literal text.

## Note for the reviewer

Material styles `important` as a tip variant (green), not GitHub's purple. Content and structure are correct; only the accent color differs from how this looks on github.com. If an amber caution treatment reads better here, `!!! warning` is a one-word change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)