### PR TITLE
fix: size status-light stale threshold to observed prober cadence

### DIFF
--- a/docs/Computing-Hardware.md
+++ b/docs/Computing-Hardware.md
@@ -31,7 +31,7 @@ Below is a list of computing resources we have available, as well as some links 
   </tbody>
 </table>
 
-Checks run every 10–15 minutes. Hover a status for details. A reading older than 30 minutes is shown as `unknown` rather than as a stale green light.
+Checks run automatically — the timestamp shows when each host was last reached. Hover a status for details. A reading older than 90 minutes is shown as `unknown` rather than as a stale green light.
 
 !!! note
     A green light only means the machine answered on the network. It does not mean Slurm is healthy, that there is free disk space, or that your jobs are running. For Hyak-wide outages and maintenance, check [UW-IT Hyak status](https://status.uw.edu/).

--- a/docs/javascripts/server-status.js
+++ b/docs/javascripts/server-status.js
@@ -16,7 +16,14 @@
 (function () {
   "use strict";
 
-  var STALE_MS = 30 * 60 * 1000; // cron runs every ~10 min; 30 min = missed 3
+  // Sized against what the probers actually deliver, not what they ask for.
+  // The GitHub Action requests */15 but is scheduled best-effort: across 20
+  // consecutive runs the observed gaps were 30-71 min (median 46), so every
+  // single interval blew through the original 30 min threshold and the lights
+  // sat at "unknown" most of each cycle. 90 min clears the worst observed gap
+  // with headroom. Once the in-network cron is running every 10 min it becomes
+  // the freshest source and this ceiling stops mattering in practice.
+  var STALE_MS = 90 * 60 * 1000;
   var SOURCES = ["internal.json", "external.json"];
 
   function fetchSource(base, name) {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,11 @@ and that the lights on the handbook page go green within a few minutes.
 - GitHub's scheduled workflows are best-effort: delayed under load, minimum
   5-minute interval, and disabled automatically after 60 days without repo
   activity. That is why the in-network cron is primary and the Action is only a
-  backstop.
+  backstop. Measured on this repo, the Action asks for `*/15` but lands every
+  30-71 minutes (median 46). The 90-minute stale threshold in
+  `docs/javascripts/server-status.js` is sized around that; if you tighten it,
+  make sure the in-network cron is actually running first, or the lights will
+  spend most of each cycle showing `unknown`.
 - To add a host: add a probe in `check_servers.py` and a `<tr data-host="...">`
   row in `docs/Computing-Hardware.md`. The JavaScript matches the two by name
   and needs no change.


### PR DESCRIPTION
Follow-up to #2484.

## The problem

The status lights were spending most of each cycle showing `unknown` even though gannet and klone were reachable the whole time.

I set the 30-minute stale threshold against the interval the GitHub Action *requests* (`*/15`) rather than what GitHub actually delivers. Measured across the last 20 runs on this repo:

```
gaps (min): 57 71 58 57 47 35 46 43 68 57 45 37 37 48 38 44 55 41 30
min=30  median=46  max=71   (the cron expression asks for 15)
gaps exceeding the 30-min threshold: 19/19
```

Every single interval blew through the threshold. The lights were green for 30 minutes after each run landed, then grey for the remaining ~16 minutes on average, and up to 41 minutes in the worst gap.

## The change

- Stale threshold 30 → 90 minutes, clearing the worst observed gap with headroom.
- Corrects the page text, which claimed "Checks run every 10–15 minutes" — not true of the current external-only setup.
- Records the measured cadence in `scripts/README.md` so the next person to touch the threshold knows what it is sized against.

## Verification

Built locally and pointed at the **live** published status data:

- At 45 minutes old — the window where the old code showed grey — gannet and klone now render `up`, with raven correctly `unknown` since no in-network prober exists yet.
- A 95-minute-old reading carrying `up: true` still renders `unknown`, so a genuinely dead prober remains visible rather than silently reporting everything green.

## Caveat

This is a mitigation, not the real fix. It buys tolerance for a slow backstop prober; it does not make the data fresher, and a dead prober now takes 90 minutes to surface instead of 30. Once the in-network cron is running every 10 minutes it becomes the freshest source, the merge logic prefers it, and this ceiling stops mattering in practice. Raven will keep reading `unknown` until then — setup steps are in `scripts/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)