### PR TITLE
docs: refresh README for tools added since last update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This repository serves as the central hub for [Roberts Lab](http://faculty.washi
 
 ## 📖 Quick Start
 
-- **New to the lab?** Start with the [Roberts Lab Handbook](https://robertslab.github.io/resources/) for comprehensive onboarding information
+- **New to the lab?** Start with the [Roberts Lab Handbook](https://robertslab.github.io/resources/) and its [Onboarding](https://robertslab.github.io/resources/Onboarding/) checklist
 - **Looking for protocols?** Browse our [Lab Protocols](https://github.com/RobertsLab/resources/tree/master/protocols) collection
+- **Need computing resources?** See [Computing Hardware](https://robertslab.github.io/resources/Computing-Hardware/), which shows live up/down status for raven, gannet, and klone
+- **Looking for data?** Try the [Histology Databank Explorer](https://robertslab.github.io/resources/histology-explorer/) or [Genomic Resources](https://robertslab.github.io/resources/Genomic-Resources/)
 - **Need help or have questions?** Submit an [issue](https://github.com/RobertsLab/resources/issues) or join the discussion on [Slack](https://genefish.slack.com)
 - **Major research projects** can be found [here](https://github.com/RobertsLab?utf8=%E2%9C%93&q=project&type=&language=)
 
@@ -17,7 +19,7 @@ This repository serves as the central hub for [Roberts Lab](http://faculty.washi
 - **Stay updated**: Watch this repository for notifications about important updates
 
 ### Contributing and Getting Help:
-- **Report issues**: Found something outdated or incorrect? [Submit an issue](https://github.com/RobertsLab/resources/issues/new)
+- **Report issues**: Found something outdated or incorrect? [Submit an issue](https://github.com/RobertsLab/resources/issues/new/choose) — templates are available for general lab support, access requests, and coding problems
 - **Suggest improvements**: Use [GitHub Discussions](https://github.com/RobertsLab/resources/discussions) for ideas and feedback  
 - **Make edits**: Click the pencil icon (✏️) on any page to edit directly, or submit a pull request
 - **Join conversations**: Connect with lab members on [Slack](https://genefish.slack.com)
@@ -37,19 +39,31 @@ This repository serves as the central hub for [Roberts Lab](http://faculty.washi
 
 ### Core Documentation:
 - **`docs/`**: Source files for the [Roberts Lab Handbook](https://robertslab.github.io/resources/) including:
-  - Lab policies and expectations
-  - Computing resources and best practices  
-  - Safety protocols and training materials
-  - Communication guidelines and onboarding information
+  - Lab culture: onboarding and offboarding, code of conduct, expectations, safety
+  - How we work: communication, project management, lab notebooks, data management
+  - Guides: scientific writing, oral presentations, outreach slides
+  - Computing and code: best practices, agentic coding tools, hardware, Klone and Raven guides
+  - Bioinformatic workflows: annotation, DNA methylation, gene expression, transcriptome assembly
+  - Self-directed tutorials (standalone HTML): `bash-tutorial.html`, `github-tutorial.html`, `agentic-ai-bootcamp.html`, `bivalve-histology-tutorial/`
+
+### Data Catalogs and Web Tools:
+- **`docs/histology-explorer/`**: [Histology Databank Explorer](https://robertslab.github.io/resources/histology-explorer/) — static site for searching the histology databank by species, project, year, tissue, and researcher, with links to slide images on owl. Includes the build scripts that regenerate its data (`build/build_index.py`, `build/make_derivatives.py`) — see its [README](docs/histology-explorer/README.md)
+- **`data-portal/`**: Self-contained portal for browsing the lab's sequencing libraries (Nightingales) and reference genomes. `build.py` regenerates `nightingales.json` from the Nightingales sheet export and `genomes.json` from `docs/Genomic-Resources.md`
+- **`igv_server/`**: IGV genome registry and annotation files for the lab's IGV server
 
 ### Lab Resources:
-- **`protocols/`**: Comprehensive collection of lab protocols, including both custom procedures and commercial kit protocols
+- **`protocols/`**: Comprehensive collection of lab protocols, including both custom procedures and commercial kit protocols. Note that protocols surfaced in the handbook navigation live in `docs/protocols/`
 - **`equipment_manuals/`**: Equipment documentation and user manuals
 - **`lab_safety_docs/`**: Safety training materials and documentation
 
+### Automation:
+- **`.github/workflows/`**: Deploys the handbook to GitHub Pages on push to `master`, probes server status every 15 minutes, and checks for broken links in Markdown files
+- **`.github/ISSUE_TEMPLATE/`**: Issue templates for lab support requests, access requests, and coding issues
+- **`scripts/`**: Server status probers (`check_servers.py`, `publish_status.sh`) that power the status lights on the Computing Hardware page. Results are published to the orphan `server-status` branch by both a GitHub Action and an in-network cron job, since raven is not reachable from outside the UW network — see [scripts/README.md](scripts/README.md)
+
 ### Administrative:
-- **`.readthedocs.yml`**: Configuration for the Roberts Lab Handbook website
-- **`mkdocs.yml`**: Configuration file for [MkDocs](https://www.mkdocs.org/) documentation generation
+- **`mkdocs.yml`**: Configuration and navigation for the [MkDocs](https://www.mkdocs.org/) handbook site
+- **`.readthedocs.yml`**: Read the Docs build configuration (the live handbook is deployed to GitHub Pages by the workflow above)
 - **`histology_request_form_2019.pdf`**: Histology sample submission form for consultation services
 
 ### Additional Resources:


### PR DESCRIPTION
## What changed

The README's **Repository Structure** section still described the repo as `docs/` + `protocols/` + `equipment_manuals/` + `lab_safety_docs/` + two config files. It was missing everything added over the past year. This brings it current.

**Added — Data Catalogs and Web Tools**
- `docs/histology-explorer/` — the Histology Databank Explorer, plus a pointer to its build scripts and README
- `data-portal/` — Nightingales sequencing libraries + reference genomes browser, and how `build.py` regenerates its JSON
- `igv_server/` — IGV genome registry and annotation files

**Added — Automation**
- `.github/workflows/` — Pages deploy on push to `master`, 15-minute server probe, Markdown URL checker
- `.github/ISSUE_TEMPLATE/`
- `scripts/` — the status probers, with a one-line note on why there are two of them (raven is not in public DNS, so the in-network cron is the only thing that can see it)

**Updated**
- Expanded the `docs/` bullet to cover sections that have grown since the last README pass: onboarding/offboarding, project management, writing and oral presentation guides, agentic coding tools, and the standalone HTML tutorials
- Quick Start now links Onboarding, Computing Hardware (with its live status lights), and the two data catalogs
- Issue reporting points at `issues/new/choose` — the old bare `issues/new` link bypassed the templates in `.github/ISSUE_TEMPLATE/`
- Noted that handbook-navigated protocols live in `docs/protocols/`, distinct from top-level `protocols/`

## Notes for reviewers

- All four new handbook URLs were checked and return 200.
- Docs-only change; no code or config touched.
- Two things left alone deliberately: `html/tjgr.markdown` (one orphaned file) and the root-level `UW_NWGC_Library_Submission_Form_2019.docx` — neither was in the old README either.
- `.readthedocs.yml` is described factually rather than as removed. It's still present but pins Python 3.7 while the live site deploys via GitHub Actions, so it may be worth deleting in a separate change if Read the Docs is genuinely no longer in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)